### PR TITLE
Fix directory separator on non-Windows platforms

### DIFF
--- a/BfresToCast/Program.cs
+++ b/BfresToCast/Program.cs
@@ -131,8 +131,8 @@ public class Program
             ResFile modelRes = new ResFile(stream);
             FileInfo fileInfo = new FileInfo(file);
             // This is stupid, Bezel engine bfres uses the fmdb extension and the name inside the bfres has it too...
-            string dir = $@"{fileInfo.DirectoryName}\{Path.GetFileNameWithoutExtension(modelRes.Name)}";
-            string texDir = $@"{dir}\Textures";
+            string dir = $@"{fileInfo.DirectoryName}{Path.DirectorySeparatorChar}{Path.GetFileNameWithoutExtension(modelRes.Name)}";
+            string texDir = $@"{dir}{Path.DirectorySeparatorChar}Textures";
             Directory.CreateDirectory(dir);
             if (modelRes.Textures.Count != 0)
             {
@@ -265,7 +265,7 @@ public class Program
                     }
                 }
 
-                CastWriter.Save($@"{dir}\{model.Name}.cast", root);
+                CastWriter.Save($@"{dir}{Path.DirectorySeparatorChar}{model.Name}.cast", root);
                 Console.WriteLine($"Saved model {model.Name}");
             }
 


### PR DESCRIPTION
Replaces the backslashes with `Path.DirectorySeparatorChar` for better cross-platform compatibility