### PR TITLE
Handling exports of single and dual channel textures

### DIFF
--- a/BfresToCast/Converter.cs
+++ b/BfresToCast/Converter.cs
@@ -7,6 +7,7 @@ using Cast.NET.Nodes;
 using ImageLibrary;
 using ImageLibrary.Imaging.Switch;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections.Generic;
@@ -89,10 +90,24 @@ namespace BfresToCast
                         TextureUtils.ToDDS(tex, encoder, deswizzled, $"{texDir}/{tex.Name}.dds");
                         Console.WriteLine($"Saved texture {tex.Name}");
                     }
+                    else if (TextureUtils.IsGrayscale(tex.Format))
+                    {
+                        var png_encoder = new PngEncoder
+                        {
+                            BitDepth = PngBitDepth.Bit8,
+                            ColorType = PngColorType.Grayscale,
+                        };
+                        var rgba = encoder.Decode(deswizzled, tex.Width, tex.Height);
+                        var r = rgba.Where((x, i) => i % 4 == 0).ToArray();
+                        var img = Image.LoadPixelData<SixLabors.ImageSharp.PixelFormats.L8>(r, (int)tex.Width, (int)tex.Height);
+                        img.SaveAsPng($"{texDir}/{tex.Name}.png", png_encoder);
+                        Console.WriteLine($"Saved grayscale texture {tex.Name}");
+                    }
                     else
                     {
                         var rgba = encoder.Decode(deswizzled, tex.Width, tex.Height);
-                        rgba = TextureUtils.ConvertChannels(rgba, tex);
+                        if (!TextureUtils.IsNrm(tex))
+                            rgba = TextureUtils.ConvertChannels(rgba, tex);
                         var img = Image.LoadPixelData<Rgba32>(rgba, (int)tex.Width, (int)tex.Height);
                         img.SaveAsPng($"{texDir}/{tex.Name}.png");
                         Console.WriteLine($"Saved texture {tex.Name}");

--- a/BfresToCast/Utils/TextureUtils.cs
+++ b/BfresToCast/Utils/TextureUtils.cs
@@ -88,6 +88,23 @@ public static class TextureUtils
         }
     }
 
+    public static bool IsNrm(SwitchTexture tex)
+    {
+        return new[] {
+            SurfaceFormat.BC5_UNORM, SurfaceFormat.BC5_SNORM,
+            SurfaceFormat.R8_G8_UNORM, SurfaceFormat.R8_G8_SNORM, SurfaceFormat.R4_G4_UNORM
+        }.Contains(tex.Format) && tex.Texture.ChannelBlue == ChannelType.Zero;
+    }
+
+
+    public static bool IsGrayscale(SurfaceFormat fmt)
+    {
+        return new[] {
+            SurfaceFormat.BC4_UNORM, SurfaceFormat.BC4_SNORM,
+            SurfaceFormat.R8_UNORM, SurfaceFormat.R16_UNORM, SurfaceFormat.R32_UNORM
+        }.Contains(fmt);
+    }
+
     public static byte[] ConvertChannels(byte[] data, SwitchTexture tex)
     {
         byte[] rgba = new byte[data.Length];


### PR DESCRIPTION
Currently, all images are either float buffers converted directly to DDS, or RGBA textures, with rearranged channels.

BC5 (along with some other RG formats) stores two channels and sets the resulting blue channel to "Zero", however it's more usable in a format where the blue channel is there. The bntx library already calculates this blue channel, but it's removed during the ConvertChannels step. This pull request detects normal maps and exports the png with the calculated blue channel.

BC4 as well as R8/16/32 only store a single channel of data. This pull request also skips the ConvertChannels and stores that data directly to a greyscale PNG, reducing size, which may be useful for large libraries of models.

# Possible issues

Currently, when detecting for a normal map, it only checks if it's a 2 channel format, and that if the blue channel type is set to "Zero". This avoids some cases where the green or red channel is copied to the blue channel (like some Mlt textures), but I'm unsure if this is enough.

The extra channel does increase file size a bit, and perhaps some people would only like to have only the two channels. Adding this as an optional command line argument might be better.

Since the original format only has 1 or 2 channels, none of this should result in any data loss, however incorrectly guessing could result in some weird output which may need to be processed manually anyway.